### PR TITLE
Fix host access in dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
 # Calculator
 
-This repository will contain a simple calculator project.
+This repository contains a simple calculator project built with React and Vite.
+
+## Development
+
+1. Install dependencies
+
+   ```bash
+   npm install
+   ```
+
+2. Start the dev server (it listens on all network interfaces so hosts like CodeSandbox can preview it)
+
+   ```bash
+   npm run dev
+   ```
+
+### Hosting environments
+
+The Vite configuration allows all hosts so the project can be previewed in
+environments like CodeSandbox or StackBlitz.

--- a/README.md
+++ b/README.md
@@ -20,3 +20,9 @@ This repository contains a simple calculator project built with React and Vite.
 
 The Vite configuration allows all hosts so the project can be previewed in
 environments like CodeSandbox or StackBlitz.
+
+After pushing this repository to GitHub, you can open it in a web editor using
+one of these links (replace `USER` and `REPO` with the actual repository path):
+
+* <https://codesandbox.io/p/github/USER/REPO>
+* <https://stackblitz.com/github/USER/REPO>

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,4 +3,9 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  server: {
+    // Allow previewing from hosted environments like CodeSandbox
+    host: '0.0.0.0',
+    allowedHosts: 'all',
+  },
 });


### PR DESCRIPTION
## Summary
- allow Vite dev server to bind to `0.0.0.0`
- document that the dev server can be accessed from hosted environments

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6840b8440a14832ea5ecb8f4e59836f7